### PR TITLE
Fullcourse show

### DIFF
--- a/app/controllers/fullcourses_controller.rb
+++ b/app/controllers/fullcourses_controller.rb
@@ -4,4 +4,9 @@ class FullcoursesController < ApplicationController
   def index
     @users = User.all
   end
+
+  def show
+    @user = User.find(params[:id])
+    @fullcourse_menus = FullcourseMenu.where(user_id: params[:id]).order(id: :asc)
+  end
 end

--- a/app/views/fullcourse_menus/show.html.erb
+++ b/app/views/fullcourse_menus/show.html.erb
@@ -1,2 +1,0 @@
-<h1>FullcourseManus#show</h1>
-<p>Find me in app/views/fullcourse_manus/show.html.erb</p>

--- a/app/views/fullcourses/_fullcourse.html.slim
+++ b/app/views/fullcourses/_fullcourse.html.slim
@@ -1,7 +1,8 @@
 - if  user.fullcourse_image.present?
   .col
-    .card.shadow-sm
-      = image_tag user.fullcourse_image.url, class: 'card-img-top', size: '300x300'
+    .card.shadow-lg.rounded
+      = link_to fullcourse_path(user.id)
+        = image_tag user.fullcourse_image.url, class: 'card-img-top', size: '300x300'
       .card-body
         ul.list-inline
           li.list-inline-item

--- a/app/views/fullcourses/_fullcourse_menu.html.slim
+++ b/app/views/fullcourses/_fullcourse_menu.html.slim
@@ -1,0 +1,22 @@
+.container
+  h1
+    = fullcourse_menu.genre_i18n
+
+  .card.shadow-lg.mb-3.bg-body.rounded
+    .row.m-2.flex
+      .col-3
+        = image_tag fullcourse_menu.menu_image.url, size: '300x200', class: 'img-fluid'
+      .col-9
+        .card-body.p-2
+          .card-title
+            h4
+              = fullcourse_menu.name
+          .card-text
+            p.mb-1
+              i.fa-solid.fa-house-chimney
+              |  
+              = fullcourse_menu.store.name
+            p.mb-1
+              i.fa-solid.fa-map-location-dot
+              |  
+              = fullcourse_menu.store.address

--- a/app/views/fullcourses/show.html.slim
+++ b/app/views/fullcourses/show.html.slim
@@ -1,0 +1,2 @@
+= image_tag @user.fullcourse_image.url, class: 'd-block my-5 mx-auto img-fluid'
+= render partial: 'fullcourse_menu', collection: @fullcourse_menus

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,6 @@ Rails.application.routes.draw do
 
   resources :users, only: %i[new create edit]
   resources :fullcourse_menus
-  resources :fullcourses, only: %i[index]
+  resources :fullcourses, only: %i[index show]
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
## 概要
- ルーティング`fullcourse_path`を追加
- フルコース一覧の画像からフルコース詳細ページに遷移するように`link_to`を追加