### PR TITLE
Fix: twitter共有ボタンのサイズを修正

### DIFF
--- a/app/views/fullcourses/show.html.slim
+++ b/app/views/fullcourses/show.html.slim
@@ -3,7 +3,7 @@
   .img.my-5.text-center
     = image_tag @user.fullcourse.fullcourse_image.url, class: 'd-block mx-auto img-fluid'
     - if @user == current_user
-      = link_to "https://twitter.com/intent/tweet?text=#{@user.name}がフルコースを作成しました!%0aフルコース完成まであと#{@user.remaining_number}つです!&hashtags=俺のフルコース",
+      = link_to "https://twitter.com/intent/tweet?text=#{@user.name}がフルコースを作成しました!%0aフルコース完成まであと#{@user.remaining_number}つです!&hashtags=俺のフルコース&size=large",
                 class: "twitter-share-button"     
                   | tweet
   = render partial: 'fullcourse_menu', collection: @fullcourse_menus


### PR DESCRIPTION
## 概要
`&size=large`という記述を追加し、twitter共有ボタンのサイズを大きめに修正
