### PR TITLE
フォームとsaveメソッドの修正

### DIFF
--- a/app/models/form/fullcourse_menu_collection.rb
+++ b/app/models/form/fullcourse_menu_collection.rb
@@ -5,7 +5,7 @@ class Form::FullcourseMenuCollection < Form::Base
   def initialize(attributes = {})
     super attributes
     self.stores = FORM_COUNT.times.map { Store.new } unless stores.present?
-    self.fullcourse_menus = stores.map { |store| store.fullcourse_menus.build } unless fullcourse_menus.present?
+    self.fullcourse_menus = FORM_COUNT.times.map { FullcourseMenu.new } unless fullcourse_menus.present?
   end
 
   # 上でsuper attributesとしているので必要
@@ -18,19 +18,21 @@ class Form::FullcourseMenuCollection < Form::Base
   end
 
   def save
-    # 実際にやりたいことはこれだけ
-    # self.memos.map(&:save!)
-
     # 複数件全て保存できた場合のみ実行したいので、transactionを使用する
-    FullcourseMenu.transaction do
-      stores.map(&:save!)
-      fullcourse_menus.map.with_index do |menu, index|
-        menu.store_id = stores[index].id
-        menu.save!
+    ActiveRecord::Base.transaction do
+      store_errors = stores.map do |store|
+        store.save
+        store.errors.any?
       end
+      menu_errors = fullcourse_menus.map.with_index do |menu, index|
+        menu.store_id = stores[index].id
+        menu.save
+        menu.errors.any?
+      end
+      raise ActiveRecord::RecordInvalid if store_errors.include?(true) || menu_errors.include?(true)
     end
     true
-  rescue StandardError => e
+  rescue => e
     false
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,10 +18,10 @@ class User < ApplicationRecord
   def multi_update(edit_fullcourse_menu_params)
     FullcourseMenu.transaction do
       edit_fullcourse_menu_params[:fullcourse_menus].to_h.map.with_index do |edit_fullcourse_menu_param, index|
-        fullcourse_menus.order(id: :asc)[index].update(edit_fullcourse_menu_param[1])
+        fullcourse_menus.order(id: :asc)[index].update!(edit_fullcourse_menu_param[1])
       end
       edit_fullcourse_menu_params[:stores].to_h.map.with_index do |edit_fullcourse_menu_param, index|
-        fullcourse_menus.order(id: :asc)[index].store.update(edit_fullcourse_menu_param[1])
+        fullcourse_menus.order(id: :asc)[index].store.update!(edit_fullcourse_menu_param[1])
       end
     end
     true

--- a/app/views/fullcourse_menus/_edit_form.html.slim
+++ b/app/views/fullcourse_menus/_edit_form.html.slim
@@ -1,6 +1,7 @@
 = form_with model: user, url: fullcourse_menu_path, local: true do |f|
   - user.fullcourse_menus.order(id: :asc).each.with_index do |fullcourse_menu, index|
     = f.fields_for "fullcourse_menus[]", fullcourse_menu do |i|
+      = render 'shared/error_messages', model: fullcourse_menu
       .form_group
         = i.label :name, "#{FullcourseMenu.genres_i18n.values[index]}"
         = i.text_field :name, class: 'form_control'

--- a/app/views/fullcourse_menus/_new_form.html.slim
+++ b/app/views/fullcourse_menus/_new_form.html.slim
@@ -1,6 +1,6 @@
 = form_with model: form, url: fullcourse_menus_path, local: true do |f|
-  = render 'shared/error_messages', model: form.fullcourse_menus[0]
   - form.fullcourse_menus.each.with_index do |fullcourse_menu, index|
+    = render 'shared/error_messages', model: fullcourse_menu
     = f.fields_for :fullcourse_menus, fullcourse_menu do |i|
       .form_group
         = i.label :name, "#{FullcourseMenu.genres_i18n.values[index]}"
@@ -10,7 +10,8 @@
         = i.file_field :menu_image, class: 'form-control mb-3', accept: 'image/*', id: "file_btn_#{index}"
         = i.hidden_field :menu_image_cache
         = image_tag fullcourse_menu.menu_image.url, id: "preview_#{index}"
-
+    
+    = render 'shared/error_messages', model: form.stores[index]
     = f.fields_for :stores, form.stores[index] do |i|
       .form_group
         = i.label :name

--- a/app/views/fullcourse_menus/_new_form.html.slim
+++ b/app/views/fullcourse_menus/_new_form.html.slim
@@ -11,7 +11,7 @@
         = i.hidden_field :menu_image_cache
         = image_tag fullcourse_menu.menu_image.url, id: "preview_#{index}"
 
-    = f.fields_for :stores, fullcourse_menu.store do |i|
+    = f.fields_for :stores, form.stores[index] do |i|
       .form_group
         = i.label :name
         = i.text_field :name, class: 'form_control', onchange: "codeAddress(#{index})", id: "name_#{index}"


### PR DESCRIPTION
## 概要
- `save`メソッドのトランザクションで`save!`を`save`にし、全ての処理が終わってから`raise`でエラーを出すよう修正
- エラーメッセージの部分テンプレートをメニュー作成、編集ページに配置
-` fields_for`で渡すモデルを`form.stores[index]`に修正
