### PR TITLE
Fullcourse image

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,4 +42,6 @@ Metrics/AbcSize:
   Enabled: false
 Metrics/BlockLength:
   Enabled: false
+Naming/MethodParameterName:
+  Enabled: false
 

--- a/app/models/form/menu_store_form.rb
+++ b/app/models/form/menu_store_form.rb
@@ -48,7 +48,7 @@ class Form::MenuStoreForm
     ActiveRecord::Base.transaction do
       errors = fullcourse_menus.map.with_index do |menu, index|
         store = params[:stores_attributes][:"#{index}"]
-        #緯度経度はfloat型なのでfind_byするために""の時にnilにする
+        # 緯度経度はfloat型なのでfind_byするために""の時にnilにする
         store[:latitude] = nil if store[:latitude].blank?
         store[:longitude] = nil if store[:longitude].blank?
         # storeはupdateしてないので、更新失敗時に入力値を返すために＠form.storesに入れる

--- a/app/models/fullcourse.rb
+++ b/app/models/fullcourse.rb
@@ -8,45 +8,19 @@ class Fullcourse < ApplicationRecord
 
   def create_fullcourse_image
     image = MiniMagick::Image.open('./app/assets/images/fullcourse.jpeg')
-    pos = '10, 5' # 基準点からの変位 '横,縦'
+    pos = '10, 10' # 基準点からの変位 '横,縦'
     menus = user.fullcourse_menus.order(id: :asc)
     image.combine_options do |config|
-      config.font './app/assets/fonts/GenEiGothicP-Regular.ttf' # フォント指定
-      config.fill '#000000' # 色指定ブラック
-      config.gravity 'NorthWest' # 基準点指定
-      config.pointsize 30 # フォントのサイズ
-      config.stroke '#FFFFFF' # 縁の色
-      config.strokewidth 6 # 縁の幅
-      config.draw "text #{pos} '#{user.name} フルコースメニュー'"
-      config.stroke '#000000'
-      config.strokewidth 0
-      config.draw "text #{pos} '#{user.name} フルコースメニュー'" # 縁取りした文字の上に通常の文字を重ねる
-
-      config.pointsize 25 # フォントのサイズ
+      # 〇〇 フルコースと書き出す
+      write_user_name(config, pos)
       menus.each.with_index do |menu, i|
-        # ジャンル、メニューを表示
-        pos = 60 * (i + 1)
-        config.stroke '#FFFFFF'
-        config.strokewidth 6
-        config.draw "text 10, #{pos} '■#{menu.genre_i18n}'"
-        config.draw "text 180, #{pos} #{menu.name}" if menu.name.present?
-        config.stroke '#000000'
-        config.strokewidth 0
-        config.draw "text 10, #{pos} '■#{menu.genre_i18n}'"
-        config.draw "text 180, #{pos} #{menu.name}" if menu.name.present?
+        x = 10
+        y = 70 + (70 * i)
+        # メニュー、店名を書き出す
+        write_menu_store(config, menu, x, y)
         # メニューがないときは空欄を表示
-        if menu.name.blank?
-          config.stroke '#FFFFFF'
-          config.strokewidth 4 # 白縁
-          config.draw "rectangle 180,#{pos - 10} 350,#{pos + 40}"
-          config.fill '#FFFFFF'
-          config.stroke '#000000'
-          config.strokewidth 1 # 中が白、縁が黒
-          config.draw "rectangle 180,#{pos - 10} 350,#{pos + 40}"
-          config.fill '#000000'
-        end
+        blank_box(config, x, y) if menu.name.blank?
       end
-
       write_lines(config, menus)
     end
     image.format 'jpg' # 拡張子を指定
@@ -54,23 +28,72 @@ class Fullcourse < ApplicationRecord
     save
   end
 
+  # 〇〇 フルコースと書き出す
+  def write_user_name(config, pos)
+    config.font './app/assets/fonts/GenEiGothicP-Regular.ttf' # フォント指定
+    config.fill '#000000' # 色指定ブラック
+    config.gravity 'NorthWest' # 基準点指定
+    config.pointsize 35 # フォントのサイズ
+    config.stroke '#FFFFFF' # 縁の色
+    config.strokewidth 6 # 縁の幅
+    config.draw "text #{pos} '#{user.name} フルコースメニュー'"
+    config.stroke '#000000'
+    config.strokewidth 0
+    config.draw "text #{pos} '#{user.name} フルコースメニュー'" # 縁取りした文字の上に通常の文字を重ねる
+  end
+
+  # メニュー、店名を書き出す
+  def write_menu_store(config, menu, x, y)
+    config.pointsize 30 # フォントのサイズ
+    menu_level = "(#{FullcourseMenu.human_attribute_name(:level)}#{menu.level})"
+    # 縁取りメニュー
+    config.stroke '#FFFFFF'
+    config.strokewidth 6
+    config.draw "text #{x}, #{y} '■#{menu.genre_i18n}'"
+    config.draw "text #{x + 220}, #{y} '#{menu.name}#{menu_level}'" if menu.name.present?
+    # 縁取り店名
+    config.pointsize 20
+    config.draw "text #{x + 220}, #{y + 35} '#{menu.store.name}'"
+    # メニュー
+    config.pointsize 30
+    config.stroke '#000000'
+    config.strokewidth 0
+    config.draw "text #{x}, #{y} '■#{menu.genre_i18n}'"
+    config.draw "text #{x + 220}, #{y} '#{menu.name}#{menu_level}'" if menu.name.present?
+    # 店名
+    config.pointsize 20
+    config.draw "text #{x + 220}, #{y + 35} '#{menu.store.name}'"
+  end
+
+  # 空欄を表示
+  def blank_box(config, x, y)
+    config.stroke '#FFFFFF'
+    config.strokewidth 4 # 白縁
+    config.draw "rectangle #{x + 220},#{y - 5} #{x + 450},#{y + 40}"
+    config.fill '#FFFFFF'
+    config.stroke '#000000' # 黒縁、中白
+    config.strokewidth 1
+    config.draw "rectangle #{x + 220},#{y - 5} #{x + 450},#{y + 40}"
+    config.fill '#000000'
+  end
+
   # セリフ
   def write_lines(config, menus)
     config.font './app/assets/fonts/GenEiAntiqueNv5-M.ttf'
-    word_1 = "あと#{menus.map(&:name).count("")}つかな"
-    word_2 = "お前は？"
+    word1 = "あと#{menus.map(&:name).count('')}つかな"
+    word2 = 'お前は？'
     config.gravity 'NorthEast'
     config.strokewidth 0
     config.pointsize 35
-    word_1.chars.each.with_index do |c, i|
-      # 数字の時はx方向の数値を変える
-      i == 2 ? x = 27 : x = 20
-      y = 50+(35*i)
+    word1.chars.each.with_index do |c, i|
+      # ３文字目の時にx方向の数値を変える
+      x = i == 2 ? 27 : 20
+      y = 50 + (35 * i)
       config.draw "text #{x}, #{y} '#{c}'"
     end
     config.pointsize 30
-    word_2.chars.each.with_index do |c, i|
-      pos = "20, #{500+(30*i)}"
+    word2.chars.each.with_index do |c, i|
+      pos = "20, #{500 + (30 * i)}"
       config.draw "text #{pos} '#{c}'"
     end
   end

--- a/app/models/fullcourse.rb
+++ b/app/models/fullcourse.rb
@@ -46,9 +46,32 @@ class Fullcourse < ApplicationRecord
           config.fill '#000000'
         end
       end
+
+      write_lines(config, menus)
     end
     image.format 'jpg' # 拡張子を指定
     self.fullcourse_image = image
     save
+  end
+
+  # セリフ
+  def write_lines(config, menus)
+    config.font './app/assets/fonts/GenEiAntiqueNv5-M.ttf'
+    word_1 = "あと#{menus.map(&:name).count("")}つかな"
+    word_2 = "お前は？"
+    config.gravity 'NorthEast'
+    config.strokewidth 0
+    config.pointsize 35
+    word_1.chars.each.with_index do |c, i|
+      # 数字の時はx方向の数値を変える
+      i == 2 ? x = 27 : x = 20
+      y = 50+(35*i)
+      config.draw "text #{x}, #{y} '#{c}'"
+    end
+    config.pointsize 30
+    word_2.chars.each.with_index do |c, i|
+      pos = "20, #{500+(30*i)}"
+      config.draw "text #{pos} '#{c}'"
+    end
   end
 end


### PR DESCRIPTION
## 概要
- フルコース画像で台詞を描画する`write_lines`メソッドを追加
- `create_fullcourse_image`メソッドを切り分け、`write_user_name, write_menu_store, blank_box`メソッドを追加
- フルコース画像に捕獲レベル、店名、台詞が表示されるように修正
- `rubocop`の`Naming/MethodParameterName`を許可する警告に追加

## 確認方法
1. フルコース画像に捕獲レベル、店名、セリフが表示されていることを確認してください
2. セリフの「あと◯つかな」の数字が空欄の数とあっているか確認してください