### PR TITLE
店舗の電話番号を取得

### DIFF
--- a/app/controllers/fullcourse_menus_controller.rb
+++ b/app/controllers/fullcourse_menus_controller.rb
@@ -66,7 +66,7 @@ class FullcourseMenusController < ApplicationController
 
   def menu_store_form_params
     params.require(:form_menu_store_form).permit(fullcourse_menus_attributes: %i[name genre menu_image menu_image_cache],
-                                                 stores_attributes: %i[name address latitude longitude])
+                                                  stores_attributes: %i[name address latitude longitude phone_number])
   end
 
   def set_user

--- a/app/controllers/fullcourse_menus_controller.rb
+++ b/app/controllers/fullcourse_menus_controller.rb
@@ -16,7 +16,7 @@ class FullcourseMenusController < ApplicationController
     if @form.save
       fullcourse = current_user.build_fullcourse
       fullcourse.create_fullcourse_image
-      redirect_to fullcourses_path
+      redirect_to fullcourse_path(current_user)
     else
       gon.lat = menu_store_form_params[:stores_attributes].to_h.map { |store| store[1][:latitude].to_f }
       gon.lng = menu_store_form_params[:stores_attributes].to_h.map { |store| store[1][:longitude].to_f }
@@ -44,7 +44,7 @@ class FullcourseMenusController < ApplicationController
     if @form.update(menu_store_form_params)
       fullcourse = @user.build_fullcourse
       fullcourse.create_fullcourse_image
-      redirect_to fullcourses_path
+      redirect_to fullcourse_path
     else
       gon.lat = menu_store_form_params[:stores_attributes].to_h.map { |store| store[1][:latitude].to_f }
       gon.lng = menu_store_form_params[:stores_attributes].to_h.map { |store| store[1][:longitude].to_f }
@@ -66,7 +66,7 @@ class FullcourseMenusController < ApplicationController
 
   def menu_store_form_params
     params.require(:form_menu_store_form).permit(fullcourse_menus_attributes: %i[name genre menu_image menu_image_cache],
-                                                  stores_attributes: %i[name address latitude longitude phone_number])
+                                                 stores_attributes: %i[name address latitude longitude phone_number])
   end
 
   def set_user

--- a/app/javascript/google_map.js
+++ b/app/javascript/google_map.js
@@ -106,25 +106,16 @@ function markerEvent(i) {
     frontMaker = markers[i];
   });  
 }
-
+//クリックした地点の緯度経度から住所をフォームに入れる
 function getClickLatLng(lat_lng, i) {
   if (markers[i]) {
   markers[i].setMap(null);
   }
-  markers[i] = new google.maps.Marker({
-    position: lat_lng,
-    map: maps[i]
-  });
-  maps[i].panTo(lat_lng);
-  //マップのクリックした地点の住所、緯度経度をフォームに入れる
   geocoder.geocode( { latLng: lat_lng}, function(results, status) {
     if (status == 'OK') {
       address = document.getElementById(`address_${i}`);
       address.value = results[0].formatted_address;
-      latitude = document.getElementById(`latitude_${i}`);
-      latitude.value = results[0].geometry.location.lat();
-      longitude = document.getElementById(`longitude_${i}`);
-      longitude.value = results[0].geometry.location.lng();
+      getLatLng(i);
     }
   });
 }

--- a/app/models/form/menu_store_form.rb
+++ b/app/models/form/menu_store_form.rb
@@ -26,15 +26,15 @@ class Form::MenuStoreForm
   def save
     # 複数件全て保存できた場合のみ実行したいので、transactionを使用する
     ActiveRecord::Base.transaction do
-      errors = fullcourse_menus.map.with_index do |menu, index|
+      errors = fullcourse_menus.map.with_index do |menu, i|
         # store.saveしてないので、作成失敗時に入力値を返すために＠form.storesに入れる
-        stores[index] = Store.find_or_create_by(name: stores[index].name, address: stores[index].address,
-                                                latitude: stores[index].latitude, longitude: stores[index].longitude)
-        menu.store_id = stores[index].id
+        stores[i] = Store.find_or_create_by(name: stores[i].name, address: stores[i].address, latitude: stores[i].latitude,
+                                            longitude: stores[i].longitude, phone_number: stores[i].phone_number)
+        menu.store_id = stores[i].id
         # 捕獲レベル算出
         menu.level = menu.calculate_level if menu.name.present?
         menu.save
-        menu.errors.any? || stores[index].errors.any?
+        menu.errors.any? || stores[i].errors.any?
       end
       # エラーを全て出すためsave!は使わずここでエラーを出す
       raise ActiveRecord::RecordInvalid if errors.include?(true)
@@ -46,18 +46,18 @@ class Form::MenuStoreForm
 
   def update(params)
     ActiveRecord::Base.transaction do
-      errors = fullcourse_menus.map.with_index do |menu, index|
-        store = params[:stores_attributes][:"#{index}"]
+      errors = fullcourse_menus.map.with_index do |menu, i|
+        store = params[:stores_attributes][:"#{i}"]
         # 緯度経度はfloat型なのでfind_byするために""の時にnilにする
         store[:latitude] = nil if store[:latitude].blank?
         store[:longitude] = nil if store[:longitude].blank?
         # storeはupdateしてないので、更新失敗時に入力値を返すために＠form.storesに入れる
-        stores[index] = Store.find_or_create_by(name: store[:name], address: store[:address],
-                                                latitude: store[:latitude], longitude: store[:longitude])
-        menu.store_id = stores[index].id
+        stores[i] = Store.find_or_create_by(name: store[:name], address: store[:address], latitude: store[:latitude],
+                                            longitude: store[:longitude], phone_number: store[:phone_number])
+        menu.store_id = stores[i].id
         menu.level = menu.calculate_level if menu.name.present?
-        menu.update(params[:fullcourse_menus_attributes][:"#{index}"])
-        menu.errors.any? || stores[index].errors.any?
+        menu.update(params[:fullcourse_menus_attributes][:"#{i}"])
+        menu.errors.any? || stores[i].errors.any?
       end
       raise ActiveRecord::RecordInvalid if errors.include?(true)
     end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -1,5 +1,5 @@
 class Store < ApplicationRecord
   has_many :fullcourse_menus, dependent: :destroy
 
-  validates :name, uniqueness: { scope: %i[address latitude longitude] }
+  validates :name, uniqueness: { scope: %i[address latitude longitude phone_number] }
 end

--- a/app/views/fullcourse_menus/_form.slim
+++ b/app/views/fullcourse_menus/_form.slim
@@ -17,54 +17,33 @@
       = f.fields_for :stores, form.stores[index] do |i|
         .form-group
           = i.label :name
-          br/
+          br
           = i.text_field :name, class: 'form-control', onchange: "codeAddress(#{index})", id: "name_#{index}"
         .form-group
           = i.label :address
-          br/
+          br
           = i.text_field :address, class: 'form-control', onchange: "getLatLng(#{index})", id: "address_#{index}"
           = i.hidden_field :latitude, id: "latitude_#{index}"
           = i.hidden_field :longitude, id: "longitude_#{index}"
+          = i.hidden_field :phone_number, id: "phone_number_#{index}"
           div id="map#{index}"
 
   = f.submit t('defaults.register'), class: 'btn btn-lg btn-primary btn-block'
 
 javascript:
-  //住所を入力すると緯度経度を取得しフォームに入れる
+  //住所を入力すると店名と住所から緯度経度、電話番号を取得しフォームに入れる
   function getLatLng(i){
-    address = document.getElementById(`address_${i}`);
-    latitude = document.getElementById(`latitude_${i}`);
-    longitude = document.getElementById(`longitude_${i}`);
-    geocoder.geocode( { 'address': address.value }, function(results, status) {
-      if (status == 'OK') {
-        maps[i].setCenter(results[0].geometry.location);
-        if (markers[i]) {
-          markers[i].setMap(null);
-        }
-        markers[i] = new google.maps.Marker({
-          map: maps[i],
-          position: results[0].geometry.location
-        });
-        latitude.value = results[0].geometry.location.lat();
-        longitude.value = results[0].geometry.location.lng();
-      }else if (!address.value){
-        if (markers[i]) {
-          markers[i].setMap(null);
-        }
-        latitude.value = null;
-        longitude.value = null;
-      }else {
-        alert('該当する結果がありませんでした：' + status); 
-      }
-    });
-  }
-  //店名入力で住所と緯度経度を取得し、フォームに入力
-  function codeAddress(i){
     inputName = document.getElementById(`name_${i}`).value;
     address = document.getElementById(`address_${i}`);
     latitude = document.getElementById(`latitude_${i}`);
     longitude = document.getElementById(`longitude_${i}`);
-    geocoder.geocode( { 'address': inputName}, function(results, status) {
+    phone_number = document.getElementById(`phone_number_${i}`);
+    service = new google.maps.places.PlacesService(maps[i]);
+    var request = {
+      query: `${inputName} ${address.value}`,
+      fields: ['formatted_address', 'geometry', 'place_id']
+    };
+    service.findPlaceFromQuery(request, function(results, status) {
       if (status == 'OK') {
         maps[i].setCenter(results[0].geometry.location);
         if (markers[i]) {
@@ -77,6 +56,66 @@ javascript:
         address.value = results[0].formatted_address;
         latitude.value = results[0].geometry.location.lat();
         longitude.value = results[0].geometry.location.lng();
+        //電話番号取得
+        var detailsRequest = {
+          placeId: results[0].place_id,
+          fields: ['formatted_phone_number']
+        };
+        service = new google.maps.places.PlacesService(maps[i]);
+        service.getDetails(detailsRequest, function(place, status) {
+          if (status == 'OK') {
+            phone_number.value = place.formatted_phone_number;
+          }
+        });
+        //住所が空欄の時、緯度経度、電話番号のフォームの値を消す
+      }else if (!address.value){
+        if (markers[i]) {
+          markers[i].setMap(null);
+        }
+        latitude.value = null;
+        longitude.value = null;
+        phone_number.value = null;
+      }
+    });
+  }
+
+  //店名入力で住所、緯度経度、電話番号を取得し、フォームに入力
+  function codeAddress(i){
+    inputName = document.getElementById(`name_${i}`).value;
+    address = document.getElementById(`address_${i}`);
+    latitude = document.getElementById(`latitude_${i}`);
+    longitude = document.getElementById(`longitude_${i}`);
+    phone_number = document.getElementById(`phone_number_${i}`);
+    service = new google.maps.places.PlacesService(maps[i]);
+    var request = {
+      query: inputName,
+      fields: ['formatted_address', 'geometry', 'place_id']
+    };
+    service.findPlaceFromQuery(request, function(results, status) {
+      if (status == 'OK') {
+        maps[i].setCenter(results[0].geometry.location);
+        if (markers[i]) {
+          markers[i].setMap(null);
+        }
+        markers[i] = new google.maps.Marker({
+          map: maps[i],
+          position: results[0].geometry.location
+        });
+        address.value = results[0].formatted_address;
+        latitude.value = results[0].geometry.location.lat();
+        longitude.value = results[0].geometry.location.lng();
+        //電話番号取得
+        var detailsRequest = {
+          placeId: results[0].place_id,
+          fields: ['formatted_phone_number']
+        };
+        service = new google.maps.places.PlacesService(maps[i]);
+        service.getDetails(detailsRequest, function(place, status) {
+          if (status == 'OK') {
+            phone_number.value = place.formatted_phone_number;
+          }
+        });
+        //店名が空欄の時フォームの全ての値を消す
       } else if (!inputName) {
         if (markers[i]) {
           markers[i].setMap(null);
@@ -84,8 +123,9 @@ javascript:
         address.value = null;
         latitude.value = null;
         longitude.value = null;
+        phone_number.value = null;
       }else {
-        alert('該当する結果がありませんでした：' + status);
+        alert('住所を入力またはマップをクッリクしてマーカーを設置してください');
       }
     });
   }

--- a/app/views/fullcourse_menus/_form.slim
+++ b/app/views/fullcourse_menus/_form.slim
@@ -44,7 +44,7 @@ javascript:
       fields: ['formatted_address', 'geometry', 'place_id']
     };
     service.findPlaceFromQuery(request, function(results, status) {
-      if (status == 'OK') {
+      if (status == 'OK' && address.value) {
         maps[i].setCenter(results[0].geometry.location);
         if (markers[i]) {
           markers[i].setMap(null);

--- a/app/views/fullcourse_menus/_fullcourse_menu.html.slim
+++ b/app/views/fullcourse_menus/_fullcourse_menu.html.slim
@@ -7,17 +7,17 @@
       .card-body.p-2
         .card-title
           h4
-            = link_to fullcourse_menu_path(fullcourse_menu.id), class: 'link'
-              = fullcourse_menu.genre_i18n
-              br
-              = fullcourse_menu.name
+            = fullcourse_menu.genre_i18n
+            .mt-2
+              = link_to fullcourse_menu_path(fullcourse_menu.id), class: 'link'
+                = fullcourse_menu.name
         .card-text
-          p.mb-1
+          p.mb-2
             = FullcourseMenu.human_attribute_name(:level)
             |  #{fullcourse_menu.level}
-          p.mb-1
-            i.fa.fa-store
-            |  #{fullcourse_menu.store.name}
-          p.mb-1
-            i.fas.fa-map-marked-alt
-            |  #{fullcourse_menu.store.address}
+          p.mb-2
+            i.fa.fa-store.me-2
+            | #{fullcourse_menu.store.name}
+          p.mb-2
+            i.fas.fa-map-marked-alt.me-2
+            | #{fullcourse_menu.store.address}

--- a/app/views/fullcourse_menus/show.html.slim
+++ b/app/views/fullcourse_menus/show.html.slim
@@ -16,7 +16,10 @@
               = @fullcourse_menu.store.name
           .card-text
             p.my-2
-                i.fas.fa-map-marked-alt
-                |  #{@fullcourse_menu.store.address}
+              i.fas.fa-map-marked-alt.me-2
+              | #{@fullcourse_menu.store.address}
+            p.my-2
+              i.fas.fa-phone-square-alt.me-2
+              | #{@fullcourse_menu.store.phone_number}
 
 script async="" defer="defer" src="https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_API_KEY']}&callback=initMap&libraries=places&v=weekly"

--- a/db/migrate/20220717145654_create_stores.rb
+++ b/db/migrate/20220717145654_create_stores.rb
@@ -8,7 +8,7 @@ class CreateStores < ActiveRecord::Migration[6.1]
       t.float :longitude
 
       t.timestamps
-      t.index [:name, :address, :latitude, :longitude], unique: true
+      t.index [:name, :address, :latitude, :longitude, :phone_number], unique: true, name: 'stores_unique_index'
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -63,7 +63,7 @@ ActiveRecord::Schema.define(version: 2022_08_27_024932) do
     t.float "longitude"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["name", "address", "latitude", "longitude"], name: "index_stores_on_name_and_address_and_latitude_and_longitude", unique: true
+    t.index ["name", "address", "latitude", "longitude", "phone_number"], name: "stores_unique_index", unique: true
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
## 概要
- フルコースメニュー作成、更新後にフルコース詳細ページに遷移するように修正
- フォームオブジェクトで、`store`の`phone_number`も登録するように修正
- `store`テーブルのユニーク制約の組み合わせに`phone_number`カラムを追加
- 店舗情報のビューに電話番号を表示
- `JavaScript`の`geocode`の部分を`findPlaceFromQuery`に修正

## 確認方法
1. フルコースメニュー作成、更新後にフルコース詳細ページに遷移することを確認してください
2.` store`テーブルのユニーク制約の組み合わせに`phone_number`カラムを追加したので `bundle exec rails db:migrate:reset` を実行してください
3. `store`テーブルの`name, address, latitude, longitude, phone_number`カラムの組み合わせが一意であることを確認してください
4. 店舗情報のビューに電話番号が表示されることを確認してください
5. フォームで店名や住所を入力した時に住所や緯度経度、マップのマーカー、電話番号が自動的に入力されることを確認してください

close #60