### PR TITLE
Fix: render.comデプロイの設定を削除

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -45,7 +45,5 @@ module MyFullcourse
 
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
-    # デプロイするサービスのホストを追加
-    config.hosts << 'my-fullcourse.onrender.com'
   end
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -30,14 +30,14 @@ pidfile ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch("WEB_CONCURRENCY") { 4 }
+# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-preload_app!
+# preload_app!
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
## 概要
- `config.hosts << 'my-fullcourse.onrender.com'`を削除
- `workers ENV.fetch("WEB_CONCURRENCY") { 4 }`と`preload_app!`をコメントアウト