### PR TITLE
Fix: ログイン前ヘッダーのロゴ画像の拡張子をjpgに修正

### DIFF
--- a/app/views/shared/_before_login_header.html.slim
+++ b/app/views/shared/_before_login_header.html.slim
@@ -2,7 +2,7 @@ header.fixed-top
   nav.navbar.navbar-expand-lg.navbar-light.bg-white
     .container-fluid
       = link_to root_path, class: 'navbar-brand'
-        = image_tag 'logo.jpeg', height: 40
+        = image_tag 'logo.jpg', height: 40
       button.navbar-toggler aria-controls="navbarNavDropdown" aria-expanded="false" aria-label=("Toggle navigation") data-bs-target="#navbarNavDropdown" data-bs-toggle="collapse" type="button" 
         span.navbar-toggler-icon
       #navbarNavDropdown.collapse.navbar-collapse.justify-content-end
@@ -17,15 +17,3 @@ header.fixed-top
             = link_to t('users.new.title'), new_user_path, class: 'nav-link'
           li
             = link_to t('defaults.login'), login_path, class: 'nav-link'
-
-
-    /ul.nav.col-12.col-lg-auto.me-lg-auto.mb-2.justify-content-center.mb-md-0
-        li
-          = link_to t('fullcourses.index.title'), fullcourses_path, class: 'nav-link.px-2.link-white'
-      .text-end
-        = link_to login_path
-          button.btn.btn-outline-primary.me-2 type="button"
-            = t('defaults.login')
-        = link_to new_user_path
-          button.btn.btn-warning type="button"
-            = t('users.new.title')


### PR DESCRIPTION
## 概要
- ログイン前ヘッダーのロゴ画像logo.jpegの拡張子をjpgに修正
- コメントアウトしていたコードを削除