### PR TITLE
validation修正

### DIFF
--- a/app/controllers/fullcourse_menus_controller.rb
+++ b/app/controllers/fullcourse_menus_controller.rb
@@ -3,7 +3,7 @@ class FullcourseMenusController < ApplicationController
   before_action :set_user, only: %i[edit update]
 
   def index
-    @fullcourse_menus = FullcourseMenu.all
+    @fullcourse_menus = FullcourseMenu.all.order(updated_at: :desc)
   end
 
   def new

--- a/app/controllers/fullcourses_controller.rb
+++ b/app/controllers/fullcourses_controller.rb
@@ -2,7 +2,7 @@ class FullcoursesController < ApplicationController
   skip_before_action :require_login
 
   def index
-    @fullcourses = Fullcourse.all.order(created_at: :desc)
+    @fullcourses = Fullcourse.all.order(updated_at: :desc)
   end
 
   def show

--- a/app/models/fullcourse_menu.rb
+++ b/app/models/fullcourse_menu.rb
@@ -2,21 +2,12 @@ class FullcourseMenu < ApplicationRecord
   belongs_to :user
   belongs_to :store
 
-  validate :menu_limit
   validates :name, presence: true, if: proc { |f| f.store.name.present? }
   validates :genre, presence: true
-  validate :store_name_presence
+  validates_associated :user, message: 'が登録できるフルコースメニューは8つまでです'
 
   mount_uploader :menu_image, MenuImageUploader
 
   enum genre: { "hors_d'oeuvre": 0, soup: 1, seafood_dish: 2, meat_dish: 3,
                 main_dish: 4, salad: 5, dessert: 6, drink: 7 }
-
-  def menu_limit
-    errors.add(:base, 'フルコースメニューを登録できるのは8つまでです') if user.fullcourse_menus.size > 8
-  end
-
-  def store_name_presence
-    store.errors.add(:name, 'を入力してください') if name.present? && store.name.blank?
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
   validates :name, presence: true
   validates :email, uniqueness: true, presence: true
   validates :reset_password_token, uniqueness: true, allow_nil: true
+  validates :fullcourse_menus, length: { maximum: 8 }
 
   mount_uploader :avatar, AvatarUploader
 

--- a/app/views/fullcourse_menus/_form.slim
+++ b/app/views/fullcourse_menus/_form.slim
@@ -1,4 +1,8 @@
 #form
+  - form.fullcourse_menus.each.with_index do |fullcourse_menu, index|
+    = render 'shared/error_messages', model: fullcourse_menu, index: index
+    = render 'shared/error_messages', model: form.stores[index], index: index
+
   .w-100.d-flex.bg-white.rounded-top.mt-3.shadow-lg
     - 8.times do |i|
         div class='btn genre-selecter' v-on:click="changeDisplay('isDisplay#{i}'); changeButton('buttonState#{i}')" v-bind:class="{ buttoncolor: buttonState#{i} }"
@@ -9,7 +13,6 @@
     - form.fullcourse_menus.each.with_index do |fullcourse_menu, index|
       div v-show="isDisplay#{index}"
         .card.rounded-0.rounded-bottom.shadow-lg.p-2.mb-3.border-top
-          = render 'shared/error_messages', model: fullcourse_menu
           = f.fields_for :fullcourse_menus, fullcourse_menu do |i|
             .form-group
               h2
@@ -26,7 +29,6 @@
               div id="delete_#{index}_image"   
                 = image_tag fullcourse_menu.menu_image.url, id: "preview_#{index}", size: '460x345', class: 'img-fluid mb-3'
 
-          = render 'shared/error_messages', model: form.stores[index]
           = f.fields_for :stores, form.stores[index] do |i|
             .form-group
               = i.label :name

--- a/app/views/fullcourse_menus/_fullcourse_menu.html.slim
+++ b/app/views/fullcourse_menus/_fullcourse_menu.html.slim
@@ -16,9 +16,11 @@
             p.mb-2
               = FullcourseMenu.human_attribute_name(:level)
               |  #{fullcourse_menu.level}
-            p.mb-2
-              i.fa.fa-store.me-2
-              | #{fullcourse_menu.store.name}
-            p.mb-2
-              i.fas.fa-map-marked-alt.me-2
-              | #{fullcourse_menu.store.address}
+            - if fullcourse_menu.store.name.present?
+              p.mb-2
+                i.fa.fa-store.me-2
+                | #{fullcourse_menu.store.name}
+            - if fullcourse_menu.store.address.present?
+              p.mb-2
+                i.fas.fa-map-marked-alt.me-2
+                | #{fullcourse_menu.store.address}

--- a/app/views/fullcourse_menus/show.html.slim
+++ b/app/views/fullcourse_menus/show.html.slim
@@ -5,23 +5,26 @@
   .row
     .col-xl-10.offset-xl-1
       = render 'fullcourse_menu', fullcourse_menu: @fullcourse_menu
-  .row
-    .col-xl-10.offset-xl-1
-      .card.shadow-lg.mb-3.bg-body.rounded
-        .row.m-2.flex
-          .col-md-3.p-0
-            #show_map
-          .col-md-9
-            .card-body.p-2
-              .card-title
-                h3
-                  = @fullcourse_menu.store.name
-              .card-text
-                p.my-2
-                  i.fas.fa-map-marked-alt.me-2
-                  | #{@fullcourse_menu.store.address}
-                p.my-2
-                  i.fas.fa-phone-square-alt.me-2
-                  | #{@fullcourse_menu.store.phone_number}
+  - if @fullcourse_menu.store.name.present?
+    .row
+      .col-xl-10.offset-xl-1
+        .card.shadow-lg.mb-3.bg-body.rounded
+          .row.m-2.flex
+            .col-md-3.p-0
+              #show_map
+            .col-md-9
+              .card-body.p-2
+                .card-title
+                  h3
+                    = @fullcourse_menu.store.name
+                .card-text
+                  - if @fullcourse_menu.store.address.present?
+                    p.my-2
+                      i.fas.fa-map-marked-alt.me-2
+                      | #{@fullcourse_menu.store.address}
+                  - if @fullcourse_menu.store.phone_number.present?
+                    p.my-2
+                      i.fas.fa-phone-square-alt.me-2
+                      | #{@fullcourse_menu.store.phone_number}
 
 script async="" defer="defer" src="https://maps.googleapis.com/maps/api/js?key=#{ENV['GOOGLE_API_KEY']}&callback=initMap&libraries=places&v=weekly"

--- a/app/views/shared/_error_messages.html.slim
+++ b/app/views/shared/_error_messages.html.slim
@@ -1,5 +1,6 @@
 - if model.errors.any?
   .alert.alert-danger
+    = FullcourseMenu.genres_i18n.values[index] if index ||= nil
     ul.mb-0
       - model.errors.full_messages.each do |msg|
         li


### PR DESCRIPTION
## 概要
- カスタムバリデーション`store_name_presence`と`menu_limit`を削除
- `User`モデルに`validates :fullcourse_menus, length: { maximum: 8 }`を追加
- フルコースメニューフォームでのエラーメッセージ表示を修正
- フルコースメニュー詳細の表示を修正

## 確認方法
1. メニュー名を入力し店名が未入力の状態でも登録できることを確認してください
2. 一人のユーザーが登録できるメニューが8つまでであることを確認してください
3. フルコースメニューフォームでエラーメッセージが下記の画像のように、上部にまとめて表示されることを確認してください
<img width="983" alt="スクリーンショット 2022-10-07 17 22 05" src="https://user-images.githubusercontent.com/91833517/194507594-38e5d280-65cf-47fb-87bd-9b9465e7c4eb.png">
4.  メニュー名を入力し店名が未入力の時、メニュー詳細では店舗情報が表示されないことを確認してください

close #85 