### PR TITLE
Fix: シングルクオートが文字列に含まれる時、画像合成ができないバグを修正 #111

### DIFF
--- a/app/controllers/fullcourse_menus_controller.rb
+++ b/app/controllers/fullcourse_menus_controller.rb
@@ -49,8 +49,8 @@ class FullcourseMenusController < ApplicationController
   def update
     @form = MenuStoreForm.new(user: @user)
     if @form.update(menu_store_form_params)
-      @user.fullcourse.delete
       fullcourse_image = CreateFullcourseImage.call(@user)
+      @user.fullcourse.delete
       fullcourse = @user.create_fullcourse(fullcourse_image: fullcourse_image)
       redirect_to fullcourse_path(fullcourse.id)
     else

--- a/app/services/create_fullcourse_image.rb
+++ b/app/services/create_fullcourse_image.rb
@@ -37,28 +37,25 @@ class CreateFullcourseImage
 
   # メニュー、店名を書き出す
   def self.write_menu_store(config, menu, x, y)
-    # 文字合成時に文字列に ' がある時エラーが出るため、 ' を削除する暫定的な処理
-    menu.name = menu.name.delete("'") if menu.name.include?("'")
-    menu.store.name = menu.store.name.delete("'") if menu.store.name.include?("'")
     config.pointsize 30 # フォントのサイズ
     menu_level = "(#{FullcourseMenu.human_attribute_name(:level)}#{menu.level})"
     # 縁取りメニュー
     config.stroke '#FFFFFF'
     config.strokewidth 6
     config.draw "text #{x}, #{y} '■#{menu.genre_i18n}'"
-    config.draw "text #{x + 220}, #{y} '#{menu.name}#{menu_level}'" if menu.name.present?
+    config.draw %(text #{x + 220}, #{y} "#{menu.name}#{menu_level}") if menu.name.present?
     # 縁取り店名
     config.pointsize 20
-    config.draw "text #{x + 220}, #{y + 35} '#{menu.store.name}'"
+    config.draw %(text #{x + 220}, #{y + 35} "#{menu.store.name}")
     # メニュー
     config.pointsize 30
     config.stroke '#000000'
     config.strokewidth 0
     config.draw "text #{x}, #{y} '■#{menu.genre_i18n}'"
-    config.draw "text #{x + 220}, #{y} '#{menu.name}#{menu_level}'" if menu.name.present?
+    config.draw %(text #{x + 220}, #{y} "#{menu.name}#{menu_level}") if menu.name.present?
     # 店名
     config.pointsize 20
-    config.draw "text #{x + 220}, #{y + 35} '#{menu.store.name}'"
+    config.draw %(text #{x + 220}, #{y + 35} "#{menu.store.name}")
   end
 
   # 空欄を表示


### PR DESCRIPTION
## 概要
シングルクオートが文字列に含まれる時、画像に文字合成ができないバグを修正 

## 確認方法
フルコースメニュー登録ページでメニュー名と店名にシングルクオートとスペースを含む文字列を入力して、画像が生成されることを確認してください

close #111 